### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/StartaleGroup/score-seadrop/security/code-scanning/7](https://github.com/StartaleGroup/score-seadrop/security/code-scanning/7)

In general, the fix is to explicitly declare a `permissions` block, either at the top level of the workflow (applying to all jobs) or per job. Since all jobs here just need to read repository contents and use the `GITHUB_TOKEN` with external actions (Coveralls, checkout) that typically require only `contents: read`, the safest and simplest fix is to set restrictive permissions at the workflow root.

The best minimal change without altering functionality is:
- Add a workflow‑level `permissions` block after the `on:` section.
- Set `contents: read` so `actions/checkout` and Coveralls can read the code and metadata but cannot make repository modifications.
No other scopes (like `pull-requests`, `issues`, etc.) appear necessary from the provided snippet. All edits occur in `.github/workflows/test.yml` around the top of the file; no imports or other files are involved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
